### PR TITLE
Added twitter:img support

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ module.exports = bundler => {
 
 		const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
 		const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
-		const twitterImageTagAbsoluteUrl = twitterImageTag.replace(twitterImageContent, absoluteOgImageUrl);
+
+		const absoluteTwitterImageUrl = url.resolve(ogUrlContent, twitterImageContent);
+		const twitterImageTagAbsoluteUrl = twitterImageTag.replace(twitterImageContent, absoluteTwitterImageUrl);
 		const patchedHtml =
 			html.replace(ogImageTag, ogImageTagAbsoluteUrl).replace(twitterImageTag, twitterImageTagAbsoluteUrl);
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const prettyMs = require('pretty-ms');
 
 const getMetaTag = (html, property) => {
-	const regex = new RegExp(`<meta[^>]*property=["|']${property}["|'][^>]*>`, 'i');
+	const regex = new RegExp(`<meta[^>]*[property|name]=["|']${property}["|'][^>]*>`, 'i');
 
 	return regex.exec(html)[0];
 };
@@ -23,7 +23,7 @@ module.exports = bundler => {
 			return;
 		}
 		console.log('');
-		const spinner = ora(chalk.grey('Fixing og:image link')).start();
+		const spinner = ora(chalk.grey('Fixing og:image and twitter:image link')).start();
 		const start = Date.now();
 
 		const htmlPath = path.join(bundler.options.outDir, 'index.html');
@@ -32,19 +32,24 @@ module.exports = bundler => {
 		const ogImageTag = getMetaTag(html, 'og:image');
 		const ogImageContent = getMetaTagContent(ogImageTag);
 
+		const twitterImageTag = getMetaTag(html, 'twitter:image');
+		const twitterImageContent = getMetaTagContent(twitterImageTag);
+
 		const ogUrlTag = getMetaTag(html, 'og:url');
 		const ogUrlContent = getMetaTagContent(ogUrlTag);
 
 		const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
 		const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
-		const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
+		const twitterImageTagAbsoluteUrl = twitterImageTag.replace(twitterImageContent, absoluteOgImageUrl);
+		const patchedHtml =
+			html.replace(ogImageTag, ogImageTagAbsoluteUrl).replace(twitterImageTag, twitterImageTagAbsoluteUrl);
 
 		fs.writeFileSync(htmlPath, patchedHtml);
 
 		const end = Date.now();
 		spinner.stopAndPersist({
 			symbol: '✨ ',
-			text: chalk.green(`Fixed og:image link in ${prettyMs(end - start)}.`)
+			text: chalk.green(`Fixed og:image and twitter:image link in ${prettyMs(end - start)}.`)
 		});
 	});
 };


### PR DESCRIPTION
I ran into the issue of getting my `og:image` URL right when building my project's files. Luckily, I found this Parcel plugin and while it does an excellent job, it does not take the `twitter:image` URL into account.

Could the fix that I proposed be merged so that Parcel in combination with this plugin remains an easy-to-use and zero-config bundler? Thanks! 👍 