### PR TITLE
Fix to run through all html files, not just one index.html

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,43 +7,44 @@ const prettyMs = require('pretty-ms');
 const glob = require('glob');
 
 const getMetaTag = (html, property) => {
-  const regex = new RegExp(`<meta[^>]*property=["|']${property}["|'][^>]*>`, 'i');
+	const regex = new RegExp(`<meta[^>]*property=["|']${property}["|'][^>]*>`, 'i');
 
-  return regex.exec(html)[0];
+	return regex.exec(html)[0];
 };
 
-const getMetaTagContent = (metaTagHtml) => {
-  const regex = /content=["]([^"]*)["]/i;
+const getMetaTagContent = metaTagHtml => {
+	const regex = /content=["]([^"]*)["]/i;
 
-  return regex.exec(metaTagHtml)[1];
+	return regex.exec(metaTagHtml)[1];
 };
 
-module.exports = (bundler) => {
-  bundler.on('buildEnd', async () => {
-    if (process.env.NODE_ENV !== 'production') {
-      return;
-    }
-    console.log('');
-    const spinner = ora(chalk.grey('Fixing og:image link')).start();
-    const start = Date.now();
+module.exports = bundler => {
+	bundler.on('buildEnd', async () => {
+		if (process.env.NODE_ENV !== 'production') {
+			return;
+		}
+		console.log('');
+		const spinner = ora(chalk.grey('Fixing og:image link')).start();
+		const start = Date.now();
 
-    glob.sync(`${bundler.options.outDir}/**/index.html`).forEach(function(file) {
-      const htmlPath = path.resolve(file);
-      const html = fs.readFileSync(htmlPath).toString();
-      const ogImageTag = getMetaTag(html, 'og:image');
-      const ogImageContent = getMetaTagContent(ogImageTag);
-      const ogUrlTag = getMetaTag(html, 'og:url');
-      const ogUrlContent = getMetaTagContent(ogUrlTag);
-      const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
-      const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
-      const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
-      fs.writeFileSync(htmlPath, patchedHtml);
-    });
+		glob.sync(`${bundler.options.outDir}/**/*.html`).forEach(file => {
+			const htmlPath = path.resolve(file);
+			const html = fs.readFileSync(htmlPath).toString();
+			const ogImageTag = getMetaTag(html, 'og:image');
+			const ogImageContent = getMetaTagContent(ogImageTag);
+			const ogUrlTag = getMetaTag(html, 'og:url');
+			const ogUrlContent = getMetaTagContent(ogUrlTag);
+			const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
+			const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
+			const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
 
-    const end = Date.now();
-    spinner.stopAndPersist({
-      symbol: '✨ ',
-      text: chalk.green(`Fixed og:image link in ${prettyMs(end - start)}.`)
-    });
-  });
+			fs.writeFileSync(htmlPath, patchedHtml);
+		});
+
+		const end = Date.now();
+		spinner.stopAndPersist({
+			symbol: '✨ ',
+			text: chalk.green(`Fixed og:image link in ${prettyMs(end - start)}.`)
+		});
+	});
 };

--- a/index.js
+++ b/index.js
@@ -8,16 +8,20 @@ const glob = require('glob');
 
 const getMetaTag = (html, property) => {
 	const regex = new RegExp(`<meta[^>]*property=["|']${property}["|'][^>]*>`, 'i');
-
-	if (regex.exec(html)) {
-		return regex.exec(html)[0];
+	const regexExec = regex.exec(html);
+	if (regexExec) {
+		return regexExec[0];
 	}
+	return false;
 };
 
 const getMetaTagContent = metaTagHtml => {
 	const regex = /content=["]([^"]*)["]/i;
-
-	return regex.exec(metaTagHtml)[1];
+	const regexExec = regex.exec(metaTagHtml);
+	if (regexExec) {
+		return regexExec[1];
+	}
+	return false;
 };
 
 module.exports = bundler => {
@@ -33,10 +37,10 @@ module.exports = bundler => {
 			const htmlPath = path.resolve(file);
 			const html = fs.readFileSync(htmlPath).toString();
 			const ogImageTag = getMetaTag(html, 'og:image');
+			const ogUrlTag = getMetaTag(html, 'og:url');
 
-			if (ogImageTag) {
+			if (ogImageTag && ogUrlTag) {
 				const ogImageContent = getMetaTagContent(ogImageTag);
-				const ogUrlTag = getMetaTag(html, 'og:url');
 				const ogUrlContent = new URL(getMetaTagContent(ogUrlTag));
 				const absoluteOgImageUrl = url.resolve(ogUrlContent.origin, ogImageContent);
 				const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);

--- a/index.js
+++ b/index.js
@@ -4,47 +4,46 @@ const url = require('url');
 const ora = require('ora');
 const chalk = require('chalk');
 const prettyMs = require('pretty-ms');
+const glob = require('glob');
 
 const getMetaTag = (html, property) => {
-	const regex = new RegExp(`<meta[^>]*property=["|']${property}["|'][^>]*>`, 'i');
+  const regex = new RegExp(`<meta[^>]*property=["|']${property}["|'][^>]*>`, 'i');
 
-	return regex.exec(html)[0];
+  return regex.exec(html)[0];
 };
 
-const getMetaTagContent = metaTagHtml => {
-	const regex = /content=["]([^"]*)["]/i;
+const getMetaTagContent = (metaTagHtml) => {
+  const regex = /content=["]([^"]*)["]/i;
 
-	return regex.exec(metaTagHtml)[1];
+  return regex.exec(metaTagHtml)[1];
 };
 
-module.exports = bundler => {
-	bundler.on('buildEnd', async () => {
-		if (process.env.NODE_ENV !== 'production') {
-			return;
-		}
-		console.log('');
-		const spinner = ora(chalk.grey('Fixing og:image link')).start();
-		const start = Date.now();
+module.exports = (bundler) => {
+  bundler.on('buildEnd', async () => {
+    if (process.env.NODE_ENV !== 'production') {
+      return;
+    }
+    console.log('');
+    const spinner = ora(chalk.grey('Fixing og:image link')).start();
+    const start = Date.now();
 
-		const htmlPath = path.join(bundler.options.outDir, 'index.html');
-		const html = fs.readFileSync(htmlPath).toString();
+    glob.sync(`${bundler.options.outDir}/**/index.html`).forEach(function(file) {
+      const htmlPath = path.resolve(file);
+      const html = fs.readFileSync(htmlPath).toString();
+      const ogImageTag = getMetaTag(html, 'og:image');
+      const ogImageContent = getMetaTagContent(ogImageTag);
+      const ogUrlTag = getMetaTag(html, 'og:url');
+      const ogUrlContent = getMetaTagContent(ogUrlTag);
+      const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
+      const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
+      const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
+      fs.writeFileSync(htmlPath, patchedHtml);
+    });
 
-		const ogImageTag = getMetaTag(html, 'og:image');
-		const ogImageContent = getMetaTagContent(ogImageTag);
-
-		const ogUrlTag = getMetaTag(html, 'og:url');
-		const ogUrlContent = getMetaTagContent(ogUrlTag);
-
-		const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
-		const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
-		const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
-
-		fs.writeFileSync(htmlPath, patchedHtml);
-
-		const end = Date.now();
-		spinner.stopAndPersist({
-			symbol: '✨ ',
-			text: chalk.green(`Fixed og:image link in ${prettyMs(end - start)}.`)
-		});
-	});
+    const end = Date.now();
+    spinner.stopAndPersist({
+      symbol: '✨ ',
+      text: chalk.green(`Fixed og:image link in ${prettyMs(end - start)}.`)
+    });
+  });
 };

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ module.exports = bundler => {
 
 			if (ogImageTag && ogUrlTag) {
 				const ogImageContent = getMetaTagContent(ogImageTag);
-				const ogUrlContent = new URL(getMetaTagContent(ogUrlTag));
-				const absoluteOgImageUrl = url.resolve(ogUrlContent.origin, ogImageContent);
+				const ogUrlContent = getMetaTagContent(ogUrlTag);
+				const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
 				const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
 				const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
 

--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ module.exports = bundler => {
 			if (ogImageTag) {
 				const ogImageContent = getMetaTagContent(ogImageTag);
 				const ogUrlTag = getMetaTag(html, 'og:url');
-				const ogUrlContent = getMetaTagContent(ogUrlTag);
-				const absoluteOgImageUrl = url.resolve(ogUrlContent, ogImageContent);
+				const ogUrlContent = new URL(getMetaTagContent(ogUrlTag));
+				const absoluteOgImageUrl = url.resolve(ogUrlContent.origin, ogImageContent);
 				const ogImageTagAbsoluteUrl = ogImageTag.replace(ogImageContent, absoluteOgImageUrl);
 				const patchedHtml = html.replace(ogImageTag, ogImageTagAbsoluteUrl);
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = bundler => {
 		const spinner = ora(chalk.grey('Fixing og:image link')).start();
 		const start = Date.now();
 
-		glob.sync(`${bundler.options.outDir}/**/*.html`).forEach(file => {
+		glob.sync(`${bundler.options.outDir}/**/index.html`).forEach(file => {
 			const htmlPath = path.resolve(file);
 			const html = fs.readFileSync(htmlPath).toString();
 			const ogImageTag = getMetaTag(html, 'og:image');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "fs": "^0.0.1-security",
+    "glob": "^7.1.6",
     "ora": "^3.4.0",
     "path": "^0.12.7",
     "pretty-ms": "^5.0.0"


### PR DESCRIPTION
Fixes my issue, https://github.com/lukechilds/parcel-plugin-ogimage/issues/5

- loops through all `.html` files
- only tries to change the `og:image` if it exists
- grabs the important bit of the url (origin), so that you can put the page name into the `og:url`
